### PR TITLE
Fix compilation with QT 5.5

### DIFF
--- a/customcontext/texture/drawhelper.h
+++ b/customcontext/texture/drawhelper.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd, author: <gunnar.sletta@jollamobile.com>
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the Scenegraph Playground module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef DRAWHELPER_H
+#define DRAWHELPER_H
+
+// Taken from qdrawhelper_p.h
+static inline uint PREMUL(uint x) {
+    uint a = x >> 24;
+    uint t = (x & 0xff00ff) * a;
+    t = (t + ((t >> 8) & 0xff00ff) + 0x800080) >> 8;
+    t &= 0xff00ff;
+
+    x = ((x >> 8) & 0xff) * a;
+    x = (x + ((x >> 8) & 0xff) + 0x80);
+    x &= 0xff00;
+    x |= t | (a << 24);
+    return x;
+}
+static inline int qt_div_255(int x) { return (x + (x>>8) + 0x80) >> 8; }
+
+#endif

--- a/customcontext/texture/eglgralloctexture.cpp
+++ b/customcontext/texture/eglgralloctexture.cpp
@@ -54,25 +54,12 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#include "drawhelper.h"
+
 // Taken from libhybris
 #define container_of(ptr, type, member) ({                  \
     const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
     (type *)( (char *)__mptr - offsetof(type,member) );})
-
-// Taken from qdrawhelper_p.h
-static inline uint PREMUL(uint x) {
-    uint a = x >> 24;
-    uint t = (x & 0xff00ff) * a;
-    t = (t + ((t >> 8) & 0xff00ff) + 0x800080) >> 8;
-    t &= 0xff00ff;
-
-    x = ((x >> 8) & 0xff) * a;
-    x = (x + ((x >> 8) & 0xff) + 0x80);
-    x &= 0xff00;
-    x |= t | (a << 24);
-    return x;
-}
-static inline int qt_div_255(int x) { return (x + (x>>8) + 0x80) >> 8; }
 
 
 #ifndef QSG_NO_RENDER_TIMING

--- a/customcontext/texture/hybristexture.cpp
+++ b/customcontext/texture/hybristexture.cpp
@@ -42,8 +42,6 @@
 #include <QtCore/qdebug.h>
 #include <QtCore/QCoreApplication>
 
-#include <QtGui/private/qdrawhelper_p.h>
-
 #include "hybristexture.h"
 
 #include <QtCore/QElapsedTimer>
@@ -52,6 +50,8 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+
+#include "drawhelper.h"
 
 #ifndef QSG_NO_RENDER_TIMING
 static bool qsg_render_timing = !qgetenv("QSG_RENDER_TIMING").isEmpty();
@@ -66,6 +66,7 @@ static QElapsedTimer qsg_renderer_timer;
 #define HYBRIS_PIXEL_FORMAT_BGRA_8888   5
 
 #define EGL_NATIVE_BUFFER_HYBRIS             0x3140
+
 
 namespace CustomContext {
 


### PR DESCRIPTION
 Added PREMUL and qt_div_255 here since we don't want to rely on a private header. It has changed in 5.5 breaking compilation.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>