### PR TITLE
[hybristextures] Prevent deleting native buffers while still in use. Fixes JB#33001

### DIFF
--- a/customcontext/texture/hybristexture.cpp
+++ b/customcontext/texture/hybristexture.cpp
@@ -272,11 +272,10 @@ NativeBuffer *NativeBuffer::create(const QImage &image)
     return buffer;
 }
 
-HybrisTexture::HybrisTexture(NativeBuffer *buffer)
+HybrisTexture::HybrisTexture(QSharedPointer<NativeBuffer> buffer)
     : m_id(0)
     , m_buffer(buffer)
     , m_bound(false)
-    , m_ownsBuffer(false)
 {
     Q_ASSERT(buffer);
 #ifdef CUSTOMCONTEXT_DEBUG
@@ -288,8 +287,6 @@ HybrisTexture::~HybrisTexture()
 {
     if (m_id)
         glDeleteTextures(1, &m_id);
-    if (m_ownsBuffer)
-        delete m_buffer;
 }
 
 void HybrisTexture::bind()
@@ -345,8 +342,7 @@ HybrisTexture *HybrisTexture::create(const QImage &image)
     NativeBuffer *buffer = NativeBuffer::create(image);
     if (!buffer)
         return 0;
-    HybrisTexture *texture = new HybrisTexture(buffer);
-    texture->m_ownsBuffer = true;
+    HybrisTexture *texture = new HybrisTexture(QSharedPointer<NativeBuffer>(buffer));
     return texture;
 }
 
@@ -360,7 +356,6 @@ HybrisTextureFactory::HybrisTextureFactory(NativeBuffer *buffer)
 
 HybrisTextureFactory::~HybrisTextureFactory()
 {
-    delete m_buffer;
 }
 
 QSGTexture *HybrisTextureFactory::createTexture(QQuickWindow *) const

--- a/customcontext/texture/hybristexture.h
+++ b/customcontext/texture/hybristexture.h
@@ -44,6 +44,7 @@
 
 #include <QtQuick/QSGTexture>
 #include <QtQuick/QQuickTextureFactory>
+#include <QSharedPointer>
 
 #include <QtGui/qopengl.h>
 
@@ -77,7 +78,7 @@ class HybrisTexture : public QSGTexture
 {
     Q_OBJECT
 public:
-    HybrisTexture(NativeBuffer *buffer);
+    HybrisTexture(QSharedPointer<NativeBuffer> buffer);
     ~HybrisTexture();
 
     virtual int textureId() const;
@@ -90,9 +91,8 @@ public:
 
 private:
     mutable GLuint m_id;
-    NativeBuffer *m_buffer;
+    QSharedPointer<NativeBuffer> m_buffer;
     bool m_bound;
-    bool m_ownsBuffer;
 };
 
 class HybrisTextureFactory : public QQuickTextureFactory
@@ -110,7 +110,7 @@ public:
     static HybrisTextureFactory *create(const QImage &image);
 
 private:
-    NativeBuffer *m_buffer;
+    QSharedPointer<NativeBuffer> m_buffer;
 };
 
 }


### PR DESCRIPTION
Share the NativeBuffer and release when the last reference is gone.

This prevents too early deletion of the NativeBuffer owned
by the texture factory while the buffer is still being used through
a non-owning HybrisTexture.